### PR TITLE
packages.txt: re-enable clang and graphviz, add git-crypt and llvm

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -36,7 +36,7 @@ bzip2
 cacert
 ccrypt
 cifs-utils
-# clang
+clang
 cloog
 cloog_0_18_0
 cmake
@@ -98,6 +98,7 @@ gettext
 gfortran
 giflib
 git
+git-crypt
 gitFull
 gitMinimal
 glib


### PR DESCRIPTION
clang and graphviz seem to work on aarch64 too, so arm might also work by now.

llvm is already covered by clang and graphviz, but it shouldn't hurt to list it explicitly.  